### PR TITLE
Framebuffer features

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -77,6 +77,7 @@ const (
 	BACK                                         = 0x0405
 	FRONT_AND_BACK                               = 0x0408
 	TEXTURE_2D                                   = 0x0DE1
+	TEXTURE_2D_MULTISAMPLE                       = 0x9100
 	CULL_FACE                                    = 0x0B44
 	BLEND                                        = 0x0BE2
 	DITHER                                       = 0x0BD0
@@ -84,6 +85,7 @@ const (
 	DEPTH_TEST                                   = 0x0B71
 	SCISSOR_TEST                                 = 0x0C11
 	POLYGON_OFFSET_FILL                          = 0x8037
+	MULTISAMPLE                                  = 0x809D
 	SAMPLE_ALPHA_TO_COVERAGE                     = 0x809E
 	SAMPLE_COVERAGE                              = 0x80A0
 	INVALID_ENUM                                 = 0x0500
@@ -305,6 +307,8 @@ const (
 	FRAMEBUFFER_UNSUPPORTED                      = 0x8CDD
 	FRAMEBUFFER_BINDING                          = 0x8CA6
 	RENDERBUFFER_BINDING                         = 0x8CA7
+	READ_FRAMEBUFFER                             = 0x8CA8
+	DRAW_FRAMEBUFFER                             = 0x8CA9
 	MAX_RENDERBUFFER_SIZE                        = 0x84E8
 	INVALID_FRAMEBUFFER_OPERATION                = 0x0506
 )

--- a/gl_opengl.go
+++ b/gl_opengl.go
@@ -115,6 +115,13 @@ func BlendFuncSeparate(sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha Enum) 
 	gl.BlendFuncSeparate(uint32(sfactorRGB), uint32(dfactorRGB), uint32(sfactorAlpha), uint32(dfactorAlpha))
 }
 
+// BlitFramebuffer copies a block of pixels from the read framebuffer to the draw framebuffer.
+//
+// http://www.khronos.org/opengles/sdk/docs/man3/html/glBlitFramebuffer.xhtml
+func BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1 int, mask, filter Enum) {
+	gl.BlitFramebuffer(int32(srcX0), int32(srcY0), int32(srcX1), int32(srcY1), int32(dstX0), int32(dstY0), int32(dstX1), int32(dstY1), uint32(mask), uint32(filter))
+}
+
 // BufferData creates a new data store for the bound buffer object.
 //
 // http://www.khronos.org/opengles/sdk/docs/man3/html/glBufferData.xhtml

--- a/gl_opengl.go
+++ b/gl_opengl.go
@@ -924,6 +924,13 @@ func TexImage2D(target Enum, level int, width, height int, format Enum, ty Enum,
 	gl.TexImage2D(uint32(target), int32(level), int32(format), int32(width), int32(height), 0, uint32(format), uint32(ty), p)
 }
 
+// TexImage2DMultisample configures a multisample texture.
+//
+// https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexImage2DMultisample.xhtml
+func TexImage2DMultisample(target Enum, samples int, internalformat Enum, width, height int, fixedsamplelocations bool) {
+	gl.TexImage2DMultisample(uint32(target), int32(samples), uint32(internalformat), int32(width), int32(height), fixedsamplelocations)
+}
+
 // TexSubImage2D writes a subregion of a 2D texture image.
 //
 // http://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage2D.xhtml

--- a/gl_opengles.go
+++ b/gl_opengles.go
@@ -556,6 +556,10 @@ func TexImage2D(target Enum, level int, width, height int, format Enum, ty Enum,
 	C.glTexImage2D(target.c(), C.GLint(level), C.GLint(format), C.GLsizei(width), C.GLsizei(height), 0, format.c(), ty.c(), p)
 }
 
+func TexImage2DMultisample(target Enum, samples int, internalformat Enum, width, height int, fixedsamplelocations bool) {
+	println("TexImage2DMultisample: not available on OpenGL ES.")
+}
+
 func TexSubImage2D(target Enum, level int, x, y, width, height int, format, ty Enum, data []byte) {
 	C.glTexSubImage2D(target.c(), C.GLint(level), C.GLint(x), C.GLint(y), C.GLsizei(width), C.GLsizei(height), format.c(), ty.c(), unsafe.Pointer(&data[0]))
 }

--- a/gl_opengles.go
+++ b/gl_opengles.go
@@ -77,6 +77,10 @@ func BlendFuncSeparate(sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha Enum) 
 	C.glBlendFuncSeparate(sfactorRGB.c(), dfactorRGB.c(), sfactorAlpha.c(), dfactorAlpha.c())
 }
 
+func BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1 int, mask, filter Enum) {
+	C.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, C.GLbitfield(mask), filter.c())
+}
+
 func BufferData(target Enum, src []byte, usage Enum) {
 	C.glBufferData(target.c(), C.GLsizeiptr(len(src)), unsafe.Pointer(&src[0]), usage.c())
 }

--- a/gl_webgl.go
+++ b/gl_webgl.go
@@ -546,6 +546,10 @@ func TexImage2D(target Enum, level int, width, height int, format Enum, ty Enum,
 	c.Call("texImage2D", target, level, format, width, height, 0, format, ty, p)
 }
 
+func TexImage2DMultisample(target Enum, samples int, internalformat Enum, width, height int, fixedsamplelocations bool) {
+	println("TexImage2DMultisample: not available on WebGL.")
+}
+
 func TexSubImage2D(target Enum, level int, x, y, width, height int, format, ty Enum, data []byte) {
 	c.Call("texSubImage2D", target, level, x, y, width, height, format, ty, data)
 }

--- a/gl_webgl.go
+++ b/gl_webgl.go
@@ -76,6 +76,11 @@ func BlendFuncSeparate(sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha Enum) 
 	c.Call("blendFuncSeparate", sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha)
 }
 
+func BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1 int, mask, filter Enum) {
+	println("BlitFramebuffer: not yet tested (TODO: remove this after it's confirmed to work. Your feedback is welcome.)")
+	c.Call("blitFramebuffer", srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter)
+}
+
 func BufferData(target Enum, data interface{}, usage Enum) {
 	c.Call("bufferData", target, data, usage)
 }

--- a/gl_webgl_wasm.go
+++ b/gl_webgl_wasm.go
@@ -649,6 +649,10 @@ func TexImage2D(target Enum, level int, width, height int, format Enum, ty Enum,
 	c.Call("texImage2D", int(target), level, int(format), width, height, 0, int(format), int(ty), SliceToTypedArray(data))
 }
 
+func TexImage2DMultisample(target Enum, samples int, internalformat Enum, width, height int, fixedsamplelocations bool) {
+	println("TexImage2DMultisample: not available on WebGL.")
+}
+
 func TexSubImage2D(target Enum, level int, x, y, width, height int, format, ty Enum, data interface{}) {
 	c.Call("texSubImage2D", int(target), level, x, y, width, height, format, int(ty), SliceToTypedArray(data))
 }

--- a/gl_webgl_wasm.go
+++ b/gl_webgl_wasm.go
@@ -190,6 +190,11 @@ func BlendFuncSeparate(sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha Enum) 
 	c.Call("blendFuncSeparate", int(sfactorRGB), int(dfactorRGB), int(sfactorAlpha), int(dfactorAlpha))
 }
 
+func BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1 int, mask, filter Enum) {
+	println("BlitFramebuffer: not yet tested (TODO: remove this after it's confirmed to work. Your feedback is welcome.)")
+	c.Call("blitFramebuffer", srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, int(mask), int(filter))
+}
+
 func BufferData(target Enum, data interface{}, usage Enum) {
 	c.Call("bufferData", int(target), SliceToTypedArray(data), int(usage))
 }


### PR DESCRIPTION
This PR enables enough GL features to implement MSAA on the desktop. On GL ES and WebGL platforms this is not supported, but `gl.BlitFramebuffer()` is now available and this can also be used for faster antialiased rendering.